### PR TITLE
feat(Mapping): accept flexible ER/HER2/TN encodings; normalize to can…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: BreastSubtypeR provides an assumption-aware, multi-method framework
     (iBreastSubtypeR) is included for interactive analyses and to support users
     without programming experience.
 Encoding: UTF-8
-Version: 1.3.1
+Version: 1.3.2
 biocViews: RNASeq, Software, GeneExpression, Classification, Preprocessing, Visualization
 Authors@R: c(
     person(given = "Qiao", family = "Yang", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# BreastSubtypeR 1.3.1
+# BreastSubtypeR 1.3.2
 
 ## Highlights (from v1.1.3 onward)
 
@@ -14,17 +14,18 @@
         Fallback: nearest-centroid (Spearman) when needed.
     -   If there are **0 common PAM50 genes**, returns `NA` labels with shaped `distances`/`dist.RORSubtype` to avoid downstream errors.
     -   ROR computation guarded for incomplete inputs.
--   **SSPBC output now “full”:** `BS_sspbc()` and Shiny “sspbc” runs return a full metrics table (not calls-only).
+-   **SSPBC output now "full":** `BS_sspbc()` and Shiny "sspbc" runs return a full metrics table (not calls-only).
     -   Exports map core label columns to the standard names (`Call_5class` / `Call_4class` when applicable).
--   **Shiny: “Load example data…” button**
+-   **Shiny: "Load example data…" button**
     -   One-click load of a small demo dataset from `inst/RshinyTest/` to explore the UI without uploads.\
     -   Shows a notification on success; users can immediately run **Preprocess & map** and analyses.
 -   **AUTO preflight UI (Shiny):** Now detects cohort kind (`TN`, `ER/HER2`, `ER`-only, `HER2`-only) and shows compact stats:
-    -   ER/HER2 subgroups: **ER+/HER2−**, **ER−/HER2−**, **ER+/HER2+**, **ER−/HER2+**\
+    -   ER/HER2 subgroups: **ER+/HER2-**, **ER-/HER2-**, **ER+/HER2+**, **ER-/HER2+**\
     -   TN cohorts: **TN** vs **nonTN**\
     -   Readiness uses the same minimums used by AUTO (sourced programmatically; no duplicated thresholds).
 -   **Shorter notifications.**\
-    -Routine toasts (e.g., “Step 1 complete. Proceed to Step 2.”) now auto-dismiss sooner to reduce UI clutter.
+    -Routine toasts (e.g., "Step 1 complete. Proceed to Step 2.") now auto-dismiss sooner to reduce UI clutter.
+-   **Phenodata normalization (Mapping):** Accepts flexible ER/HER2/TN encodings and normalizes to canonical forms (`ER+/ER-`, `HER2+/HER2-`, `TN/nonTN`). Ambiguous `HER2="2+"` remains as-is and raises a warning.
 
 ### Bug fixes
 
@@ -46,11 +47,12 @@
 
 ### Documentation
 
--   README/vignette: brief note on the example-data button and expected file locations.
+-   **README/vignette:** brief note on the example-data button and expected file locations.
+-   **Mapping(): Column metadata clarified.** Added explicit requirements for receptor fields used by AUTO and ER/HER2/TN-dependent methods (`ssBC`, `cIHC`/`cIHC.itr`, `PCAPAM50`) and for ROR covariates (`TSIZE`, `NODE` as numeric 0/1). Documented preferred coding and automatic normalization behavior.
 
 ### Compatibility Notes
 
--   SSPBC “full” output keeps previous columns for calls; additional metrics may appear.
+-   SSPBC "full" output keeps previous columns for calls; additional metrics may appear.
 
 ## Upgrade Notes
 

--- a/man/Mapping.Rd
+++ b/man/Mapping.Rd
@@ -28,7 +28,32 @@ Mapping(
 \item If row names are gene symbols, provide an additional \code{SYMBOL} column,
 renamed as \code{probe}.
 }
-\item \strong{Column metadata} (optional): sample-level metadata in \code{colData()}.
+\item \strong{Column metadata}: sample-level metadata in \code{colData()}. Specifically:
+\itemize{
+\item \code{PatientID} (\strong{required}).
+\item \strong{Receptor fields required by specific methods} (and by \code{BS_Multi()} / AUTO):
+\itemize{
+\item \code{ER} — required for \code{ssBC}, \code{cIHC} / \code{cIHC.itr}, \code{PCAPAM50}, and AUTO.
+\item \code{HER2} — required for \code{ssBC} with \code{s="ER.v2"} and for AUTO.
+\item \code{TN} — required for \code{ssBC} with \code{s="TN"} / \code{"TN.v2"} and for AUTO when TN logic is used.
+}
+\item \strong{Clinical covariates for ROR (NC-based methods only)}:
+\itemize{
+\item \code{TSIZE}: Tumor size (0 = \eqn{\le 2}{<= 2} cm; 1 = \eqn{> 2}{> 2} cm). Must be numeric (0/1).
+\item \code{NODE}: Lymph node status (0 = negative; \eqn{\ge 1}{>= 1} = positive). Must be numeric (0/1).
+}
+\item \strong{Preferred canonical receptor coding}:
+\itemize{
+\item \code{ER}: \verb{ER+}, \verb{ER-}
+\item \code{HER2}: \verb{HER2+}, \verb{HER2-}  (note: \strong{HER2 "2+" is not coerced})
+\item \code{TN}: \code{TN}, \code{nonTN}
+}
+\item \strong{Automatic normalization}: \code{Mapping()} maps common variants to canonical forms
+(e.g., \code{Pos}/\code{Neg}, \code{Positive}/\code{Negative}, \code{1}/\code{0}, \code{True}/\code{False}).
+Ambiguous \code{HER2="2+"} is \strong{not} remapped.
+\item These receptor fields are \strong{not required} for purely SSP methods (\code{AIMS}, \code{sspbc}) or for
+PAM50 when used without AUTO/ROR; they are recommended so AUTO can select suitable methods.
+}
 }}
 
 \item{RawCounts}{Logical. If \code{TRUE}, indicates that \code{assay()} holds raw RNA-seq counts.
@@ -75,6 +100,11 @@ intrinsic subtyping workflows (NC- and SSP-based).
 
 This design allows users to supply a single expression format, while
 BreastSubtypeR automatically applies method-specific preprocessing.
+
+\strong{Phenodata normalization.} #' If receptor fields are present, they are coerced to canonical encodings
+(\code{ER -> \{ER+, ER-\}}, \code{HER2 -> \{HER2+, HER2-\}},
+\code{TN -> \{TN, nonTN\}}). Ambiguous values (e.g., \code{HER2 == "2+"})
+are left unchanged and emit a warning.
 }
 \examples{
 if (requireNamespace("SummarizedExperiment", quietly = TRUE)) {


### PR DESCRIPTION
…onical forms

- Add `.normalize_er_her2_tn()` utility and call it inside `Mapping()` to coerce common variants to:
    * ER   → {ER+, ER-}
    * HER2 → {HER2+, HER2-}   (HER2 "2+" left unchanged/unevaluable)
    * TN   → {TN, nonTN}
  Accepts Positive/Negative, Pos/Neg, Yes/No, True/False, 1/0, AMP→HER2+, etc.
- Preserve original values in `colData` when fields are absent; only touch present columns.
- Emit explicit warnings on ambiguous/unmappable values (e.g., HER2 "2+").
- Roxygen: expand `Mapping()` docs with required Column metadata for AUTO/ssBC/cIHC/PCAPAM50
  and numeric TSIZE/NODE (0/1) for ROR; document the canonical receptor coding and the
  automatic normalization behavior.

Closes #122