### PR TITLE
cIHC.itr: return distances as numeric matrix, preserve dimnames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,13 +25,18 @@
     -   Readiness uses the same minimums used by AUTO (sourced programmatically; no duplicated thresholds).
 -   **Shorter notifications.**\
     -Routine toasts (e.g., "Step 1 complete. Proceed to Step 2.") now auto-dismiss sooner to reduce UI clutter.
--   **Phenodata normalization (Mapping):** Accepts flexible ER/HER2/TN encodings and normalizes to canonical forms (`ER+/ER-`, `HER2+/HER2-`, `TN/nonTN`). Ambiguous `HER2="2+"` remains as-is and raises a warning.
+-   **Phenodata normalization (Mapping):** Accepts flexible ER/HER2/TN encodings and
+normalizes to canonical forms (`ER+/ER-`, `HER2+/HER2-`, `TN/nonTN`). 
+Ambiguous `HER2="2+"` remains as-is and raises a warning.
 
 ### Bug fixes
 
--   **TN cohorts + ssBC**: `BS_Multi()` now respects TN cohorts when methods are specified manually; `ssBC`/`ssBC.v2` switch to `s = "TN"` / `"TN.v2"` when a `TN` column indicates a TN cohort. Falls back to `s = "ER"` / `"ER.v2"` otherwise.
+-   **TN cohorts + ssBC**: `BS_Multi()` now respects TN cohorts when methods are specified manually;
+`ssBC`/`ssBC.v2` switch to `s = "TN"` / `"TN.v2"` when a `TN` column indicates a TN cohort.
+Falls back to `s = "ER"` / `"ER.v2"` otherwise.
 -   **AUTO internals**: fixed variable name typo (`samples_ERHER2.icd`).
 -   **Mapping():** Robust ENTREZID coercion (from `as.character()` to `as.integer()` with suppressed warnings).
+-   **cIHC.itr**: `outList$distances` now returned as numeric matrix.
 
 ### Shiny
 

--- a/R/NC_functions.R
+++ b/R/NC_functions.R
@@ -1080,7 +1080,7 @@ makeCalls_ihc.iterative <- function(
 
                 mbal.ihc <- mat[, c(ERP.ihc$PatientID[i], ERN.ihc$PatientID)]
 
-                suffix <- getsuffix(calibration = calibration, internal)
+                suffix <- getsuffix(calibration = calibration, internal = internal)
 
                 # Calculate median
                 mdns <- apply(mbal.ihc, 1, median, na.rm = TRUE)
@@ -1156,23 +1156,41 @@ makeCalls_ihc.iterative <- function(
 
     mean_eve <- get_average_subtype(res_ihc_iterative, consensus_subtypes)
 
+    TD <- as.matrix(mean_eve$testdata)
+    storage.mode(TD) <- "double"
+    
+    D <- mean_eve$mean_distance
+    D <- as.matrix(data.matrix(D))
+
+    if (is.null(rownames(D))) rownames(D) <- names(consensus_subtypes)
+    if (is.null(colnames(D))) colnames(D) <- colnames(centroids)
+    storage.mode(D) <- "double"
+    D <- -1 * D
+    
+    D4 <- mean_eve$mean_distance.Subtype
+    D4 <- as.matrix(data.matrix(D4))
+    if (is.null(rownames(D4))) rownames(D4) <- rownames(D)
+    if (is.null(colnames(D4))) colnames(D4) <- colnames(centroids)[seq_len(4)]
+    storage.mode(D4) <- "double"
+    D4 <- -1 * D4
+    
     if (Subtype) {
-        out <- list(
-            predictions = consensus_subtypes,
-            predictions.FourSubtype = cs_FourSubtype,
-            testData = mean_eve$testdata,
-            distances = -1 * mean_eve$mean_distance,
-            dist.RORSubtype = -1 * mean_eve$mean_distance.Subtype,
-            centroids = centroids
-        )
+      out <- list(
+        predictions           = consensus_subtypes,
+        predictions.FourSubtype = cs_FourSubtype,
+        testData              = TD,
+        distances             = D,
+        dist.RORSubtype       = D4,
+        centroids             = centroids
+      )
     } else {
-        out <- list(
-            predictions = consensus_subtypes,
-            testData = mean_eve$testdata,
-            distances = -1 * mean_eve$mean_distance,
-            dist.RORSubtype = -1 * mean_eve$mean_distance.Subtype,
-            centroids = centroids
-        )
+      out <- list(
+        predictions       = consensus_subtypes,
+        testData          = TD,
+        distances         = D,
+        dist.RORSubtype   = D4,
+        centroids         = centroids
+      )
     }
 
     ## calculate and grouping


### PR DESCRIPTION
- Coerce mean_distance and mean_distance.Subtype to double matrices with sample/centroid dimnames; negate once.
- Ensure testData is numeric matrix.
- Use explicit getsuffix(calibration=..., internal=...).

Closes #112